### PR TITLE
configure.ac: fix broken cap check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,9 +127,13 @@ AS_IF([test "x$with_ncurses" = "xyes"],
 ])
 AM_CONDITIONAL([WITH_CURSES], [test "x$with_ncurses" = xyes])
 
-AC_CHECK_LIB([cap], [cap_set_proc], [have_cap="yes"],
-  AS_IF([test "$host_os" = linux-gnu],
-    AC_MSG_WARN([Capabilities support is strongly recommended for increased security.  See SECURITY for more information.])))
+have_cap="yes"
+AC_CHECK_LIB([cap], [cap_set_proc], [], [
+  have_cap="no"
+  AS_IF([test "$host_os" = linux-gnu], [
+    AC_MSG_WARN([Capabilities support is strongly recommended for increased security.  See SECURITY for more information.])
+  ])
+])
 
 # Enable ipinfo
 AC_ARG_WITH([ipinfo],


### PR DESCRIPTION
Since 9eddfacd8e9b9c2f4ce6f7ef98814bff02b5a2b7 the binding to libcap and dropping of capabilities has been silently broken.

As the docs for `AC_CHECK_LIB` are written 

 > If action-if-found is not specified, the default action prepends -llibrary to LIBS and defines ‘HAVE_LIBlibrary’ (in all capitals).

After said commit, action-if-found _was_ specified, and thus HAVE_LIBCAP wasn't defined anymore, nor was `-lcap` added to the LIBS variable.

This PR fixes this by inverting the `$have_cap` definition